### PR TITLE
Run sanity test once per ansible version

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -18,7 +18,7 @@ jobs:
 # https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html
 
   sanity:
-    name: Sanity (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
+    name: Sanity (Ⓐ${{ matrix.ansible }})
     strategy:
       matrix:
         ansible:
@@ -27,12 +27,6 @@ jobs:
         # - stable-2.9 # Only if your collection supports Ansible 2.9
           - stable-2.10
           - devel
-        python:
-          - 2.7
-          - 3.7
-          - 3.8
-        exclude:
-          - python: 3.8  # blocked by ansible/ansible#70155
     runs-on: ubuntu-latest
     steps:
 
@@ -44,20 +38,22 @@ jobs:
         with:
           path: ansible_collections/NAMESPACE/COLLECTION_NAME
 
-      - name: Set up Python ${{ matrix.ansible }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python }}
+          # it is just required to run that once as "ansible-test sanity" in the docker image
+          # will run on all python versions it supports.
+          python-version: 3.8
 
       # Install the head of the given branch (devel, stable-2.10)
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       # run ansible-test sanity inside of Docker.
-      # The docker container has all the pinned dependencies that are required.
-      # Explicity specify the version of Python we want to test
+      # The docker container has all the pinned dependencies that are required
+      # and all python versions ansible supports.
       - name: Run sanity tests
-        run: ansible-test sanity --docker -v --color --python ${{ matrix.python }}
+        run: ansible-test sanity --docker -v --color
         working-directory: ./ansible_collections/NAMESPACE/COLLECTION_NAME
 
 ###


### PR DESCRIPTION
No need to run in a python version matrix as the sanity test run in docker container will run test for all python version ansible supports.